### PR TITLE
Potential fix for code scanning alert no. 119: Syntax error

### DIFF
--- a/.github/workflows/build-termux-repo.yml
+++ b/.github/workflows/build-termux-repo.yml
@@ -242,7 +242,7 @@ RUNNER_EOF
 
                 if [ -f "$TERMUX_PREFIX/bin/$pkg" ]; then
                   HAS_BINARY=true
-                  echo "  termux_step_make_install: OK (bin/$pkg terbuat)"
+                  echo "  termux_step_make_install OK (bin/$pkg terbuat)"
                 else
                   FILE_COUNT=$(find "$PKG_BUILD/data" -type f 2>/dev/null | wc -l)
                   if [ "$FILE_COUNT" -gt 0 ]; then


### PR DESCRIPTION
Potential fix for [https://github.com/djunekz/termux-app-store/security/code-scanning/119](https://github.com/djunekz/termux-app-store/security/code-scanning/119)

To fix this without changing behavior, update the problematic `echo` line in `.github/workflows/build-termux-repo.yml` to avoid punctuation patterns that can be misread when YAML block parsing is fragile.  
Best single fix: change the message text to remove the colon after `termux_step_make_install` (and keep it a normal quoted shell string). This preserves workflow logic and only alters log text.

Edit region: around line 245 in `.github/workflows/build-termux-repo.yml`, inside the `if [ -f "$TERMUX_PREFIX/bin/$pkg" ]; then` branch.

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
